### PR TITLE
remove init_on_cpu because it does not take effect

### DIFF
--- a/AutoDL Design/inception_train/nn.py
+++ b/AutoDL Design/inception_train/nn.py
@@ -27,7 +27,6 @@ import paddle.fluid.layers.ops as ops
 import paddle.fluid as fluid
 from paddle.fluid.layers.learning_rate_scheduler import _decay_step_counter
 import math
-from paddle.fluid.initializer import init_on_cpu
 from models import inception
 from absl import flags
 
@@ -66,8 +65,7 @@ class CIFARModel(object):
                 Applies cosine decay to the learning rate.
             """
             global_step = _decay_step_counter()
-            with init_on_cpu():
-                frac = (1 + ops.cos(global_step / max_step * math.pi)) / 2
+            frac = (1 + ops.cos(global_step / max_step * math.pi)) / 2
             return FLAGS.lr_min + (FLAGS.lr_max - FLAGS.lr_min) * frac
 
         self.lr_strategy = cosine_decay

--- a/LRC/learning_rate.py
+++ b/LRC/learning_rate.py
@@ -27,7 +27,6 @@ import paddle.fluid as fluid
 import paddle.fluid.layers.ops as ops
 from paddle.fluid.layers.learning_rate_scheduler import _decay_step_counter
 import math
-from paddle.fluid.initializer import init_on_cpu
 
 
 def cosine_decay(learning_rate, num_epoch, steps_one_epoch):
@@ -36,10 +35,9 @@ def cosine_decay(learning_rate, num_epoch, steps_one_epoch):
     """
     global_step = _decay_step_counter()
 
-    with init_on_cpu():
-        decayed_lr = learning_rate * \
-                 (ops.cos(fluid.layers.floor(global_step / steps_one_epoch) \
-                 * math.pi / num_epoch) + 1)/2
+    decayed_lr = learning_rate * \
+             (ops.cos(fluid.layers.floor(global_step / steps_one_epoch) \
+             * math.pi / num_epoch) + 1)/2
     return decayed_lr
 
 

--- a/NAS-Models/train_cifar.py
+++ b/NAS-Models/train_cifar.py
@@ -69,7 +69,6 @@ def cosine_decay_with_warmup(learning_rate, step_each_epoch, epochs=120):
   decrease lr for every mini-batch and start with warmup.
   """
     from paddle.fluid.layers.learning_rate_scheduler import _decay_step_counter
-    from paddle.fluid.initializer import init_on_cpu
     global_step = _decay_step_counter()
     lr = fluid.layers.tensor.create_global_var(
         shape=[1],
@@ -81,17 +80,16 @@ def cosine_decay_with_warmup(learning_rate, step_each_epoch, epochs=120):
     warmup_epoch = fluid.layers.fill_constant(
         shape=[1], dtype='float32', value=float(5), force_cpu=True)
 
-    with init_on_cpu():
-        epoch = ops.floor(global_step / step_each_epoch)
-        with fluid.layers.control_flow.Switch() as switch:
-            with switch.case(epoch < warmup_epoch):
-                decayed_lr = learning_rate * (global_step /
-                                              (step_each_epoch * warmup_epoch))
-                fluid.layers.tensor.assign(input=decayed_lr, output=lr)
-            with switch.default():
-                decayed_lr = learning_rate * \
-                  (ops.cos((global_step - warmup_epoch * step_each_epoch) * (math.pi / (epochs * step_each_epoch))) + 1)/2
-                fluid.layers.tensor.assign(input=decayed_lr, output=lr)
+    epoch = ops.floor(global_step / step_each_epoch)
+    with fluid.layers.control_flow.Switch() as switch:
+        with switch.case(epoch < warmup_epoch):
+            decayed_lr = learning_rate * (global_step /
+                                          (step_each_epoch * warmup_epoch))
+            fluid.layers.tensor.assign(input=decayed_lr, output=lr)
+        with switch.default():
+            decayed_lr = learning_rate * \
+              (ops.cos((global_step - warmup_epoch * step_each_epoch) * (math.pi / (epochs * step_each_epoch))) + 1)/2
+            fluid.layers.tensor.assign(input=decayed_lr, output=lr)
     return lr
 
 


### PR DESCRIPTION
The usage of `init_on_cpu` does not take effect because it only works for some Ops with `force_cpu` Attr. For more information, please refer to this [PR](https://github.com/PaddlePaddle/models/pull/4164) in models repo.